### PR TITLE
check message type using instanceof

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -166,7 +166,7 @@ export class Client extends EventEmitter {
       }
 
       /*Codes_SRS_NODE_IOTHUB_CLIENT_05_014: [The `send` method shall convert the `message` object to type `azure-iot-common.Message` if it is not already of type `azure-iot-common.Message`.]*/
-      if ((<any>message.constructor).name !== 'Message') {
+      if (!(message instanceof Message)) {
         /*Codes_SRS_NODE_IOTHUB_CLIENT_18_016: [The `send` method shall throw an `ArgumentError` if the `message` argument is not of type `azure-iot-common.Message` or `azure-iot-common.Message.BufferConvertible`.]*/
         if (!Message.isBufferConvertible(message)) {
           throw new errors.ArgumentError('message is not of type Message or Message.BufferConvertible');


### PR DESCRIPTION
In 'Client.send', message type is checked using `message.constructor.name !== 'Message'`.

If your code is bundled/minified, the constructor of the `Message` class may no longer be named 'message', so it is better to check it using instanceof, which would still work with minified code.